### PR TITLE
Foundational Collider setup

### DIFF
--- a/UnityGame/Assets/Scenes/SampleScene.unity
+++ b/UnityGame/Assets/Scenes/SampleScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 705507994}
-  m_IndirectSpecularColor: {r: 0.44657844, g: 0.49641222, b: 0.57481694, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657868, g: 0.49641263, b: 0.57481706, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -96,6 +96,7 @@ LightmapSettings:
     m_PVRFilteringAtrousPositionSigmaAO: 1
     m_ExportTrainingData: 0
     m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
   m_LightingDataAsset: {fileID: 0}
   m_UseShadowmask: 1
 --- !u!196 &4
@@ -134,7 +135,7 @@ GameObject:
   - component: {fileID: 691547969}
   m_Layer: 0
   m_Name: Plane
-  m_TagString: Untagged
+  m_TagString: Ground
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -167,6 +168,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -238,8 +240,9 @@ Light:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 705507993}
   m_Enabled: 1
-  serializedVersion: 9
+  serializedVersion: 10
   m_Type: 1
+  m_Shape: 0
   m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
   m_Intensity: 1
   m_Range: 10
@@ -322,7 +325,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 88c45a6fbf8d03749a569514930c2e75, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  isTouchingGround: 0
+  IsTouchingGround: 1
 --- !u!54 &883865334
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -446,6 +449,10 @@ PrefabInstance:
     - target: {fileID: 100266, guid: 27e3c549033357241839f93f716e98b3, type: 3}
       propertyPath: m_Name
       value: Jeremy
+      objectReference: {fileID: 0}
+    - target: {fileID: 100266, guid: 27e3c549033357241839f93f716e98b3, type: 3}
+      propertyPath: m_TagString
+      value: Player
       objectReference: {fileID: 0}
     - target: {fileID: 400266, guid: 27e3c549033357241839f93f716e98b3, type: 3}
       propertyPath: m_LocalPosition.x

--- a/UnityGame/Assets/Scripts/JeremyController.cs
+++ b/UnityGame/Assets/Scripts/JeremyController.cs
@@ -4,22 +4,31 @@ using UnityEngine;
 
 public class JeremyController : MonoBehaviour
 {
-    // Start is called before the first frame update
-    public bool isTouchingGround;
+    private bool _isTouchingGround;
     private float speed;
     private float walkSpeed = 0.05f;
     private float runSpeed = 0.1f;
     private float turnSpeed = 1.5f;
     private float jumpHeight=5f;
+    
     Rigidbody rbody;
     Animator animator;
     CapsuleCollider capsuleCollider;
+    
+    public bool IsTouchingGround{
+        get{ return _isTouchingGround; }
+        set{
+            _isTouchingGround = value;
+            animator.SetBool("isTouchingGround", value);
+        }
+    }
+    
+    // Start is called before the first frame update
     void Start()
     {
         rbody = GetComponent<Rigidbody>();
         animator = GetComponent<Animator>();
         capsuleCollider = GetComponent<CapsuleCollider>();
-        isTouchingGround = true;
         animator.SetBool("isWalking", false);
         animator.SetBool("isRunning", false);
         animator.SetBool("isIdle", true);
@@ -32,13 +41,12 @@ public class JeremyController : MonoBehaviour
         var y = Input.GetAxis("Horizontal") * turnSpeed;
         transform.Translate(0, 0, z);
         transform.Rotate(0, y, 0);
-        if (Input.GetKey(KeyCode.Space) && isTouchingGround)
+        if (Input.GetKey(KeyCode.Space) && IsTouchingGround)
         {
             Debug.Log("Jumpy jump!");
             rbody.AddForce(transform.up*jumpHeight,ForceMode.Impulse);
-            isTouchingGround = false;
-            animator.SetBool("isTouchingGround", false);
-            Debug.Log(isTouchingGround);
+            IsTouchingGround = false;
+            Debug.Log(IsTouchingGround);
         }
         else if (Input.GetKey(KeyCode.LeftShift))
         {
@@ -90,11 +98,12 @@ public class JeremyController : MonoBehaviour
         }
 
     }
-    void OnCollisionEnter()
+    void OnCollisionEnter(Collision coll)
     {
         Debug.Log("Collision!");
-        isTouchingGround = true;
-        animator.SetBool("isTouchingGround",true);
+        if(coll.gameObject.CompareTag("Ground"))
+            IsTouchingGround = true;
+        // else: check for Booster, Enemy, etc.
     }
 
 }

--- a/UnityGame/ProjectSettings/TagManager.asset
+++ b/UnityGame/ProjectSettings/TagManager.asset
@@ -3,7 +3,9 @@
 --- !u!78 &1
 TagManager:
   serializedVersion: 2
-  tags: []
+  tags:
+  - Ground
+  - Powerup
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
* Only reset `IsTouchingGround` when what Jeremy touches is tagged as Ground
* Prevent inconsistent state (i.e. desync between MonoBehaviour and Animator) by using a C# Property instead of a simple field